### PR TITLE
179 refactor citation methods

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,34 +22,12 @@ module ApplicationHelper
     end
   end
 
-
-
-  # def last_updated(entity)
-  #   "Last updated #{formatted_date(entity)} by "
-  # end
-
   def last_updated(entity)
     if entity.to_s.include? "by"
-      "Last updated #{entity.datestamp} by #{link_to entity.user}"
+      "Last updated #{entity.updated_string} by #{link_to(entity.user)}".html_safe
     else
-      "Last updated #{entity.datestamp}"
+      "Last updated #{entity.updated_string}"
     end
-  end
-
-  def formatted_date(entity)
-    entity.updated_at&.to_formatted_s(:long)
-  end
-
-  def collected_on(entity)
-    entity.collected_on&.to_formatted_s(:long)
-  end
-
-  def observed_on(entity)
-    entity.observed_on&.to_formatted_s(:long)
-  end
-
-  def measured_on(entity)
-    entity.measured_on&.to_formatted_s(:long)
   end
 
   def nutrient_table_data(sample, nutrient)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,8 +22,18 @@ module ApplicationHelper
     end
   end
 
+
+
+  # def last_updated(entity)
+  #   "Last updated #{formatted_date(entity)} by "
+  # end
+
   def last_updated(entity)
-    "Last updated #{formatted_date(entity)} by "
+    if entity.to_s.include? "by"
+      "Last updated #{entity.datestamp} by #{link_to entity.user}"
+    else
+      "Last updated #{entity.datestamp}"
+    end
   end
 
   def formatted_date(entity)

--- a/app/models/biodiversity_report.rb
+++ b/app/models/biodiversity_report.rb
@@ -19,12 +19,16 @@ class BiodiversityReport < ApplicationRecord
 
   paginates_per 10
 
-  def to_s
-    "Biodiversity Report #{id}"
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    measured_on&.to_formatted_s(:long)
   end
 
-  def byline
-    "by #{author} on #{measured_on&.to_formatted_s(:long)} at #{measured_at&.to_formatted_s(:ampm)}"
+  def to_s
+    "Biodiversity Report #{id}"
   end
 
   def user

--- a/app/models/fungi_sample.rb
+++ b/app/models/fungi_sample.rb
@@ -13,6 +13,10 @@ class FungiSample < ApplicationRecord
 
   paginates_per 10
 
+  def datestamp
+    updated_at&.to_formatted_s(:long)
+  end 
+
   def to_s
     "#{plot} on #{collected_on} by #{user}"
   end

--- a/app/models/fungi_sample.rb
+++ b/app/models/fungi_sample.rb
@@ -13,9 +13,13 @@ class FungiSample < ApplicationRecord
 
   paginates_per 10
 
-  def datestamp
+  def updated_string
     updated_at&.to_formatted_s(:long)
   end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
 
   def to_s
     "#{plot} on #{collected_on} by #{user}"

--- a/app/models/lichen_sample.rb
+++ b/app/models/lichen_sample.rb
@@ -12,6 +12,14 @@ class LichenSample < ApplicationRecord
 
   paginates_per 10
 
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
+
   def to_s
     "#{plot} on #{collected_on} by #{user}"
   end

--- a/app/models/macroinvertebrate_sample.rb
+++ b/app/models/macroinvertebrate_sample.rb
@@ -15,6 +15,14 @@ class MacroinvertebrateSample < ApplicationRecord
   validates :photo, content_type: ['image/jpg', 'image/png', 'image/jpeg']
 
   paginates_per 10
+  
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
 
   def to_s
     "#{plot} on #{collected_on} by #{user}"

--- a/app/models/mycorrhizal_fungi_sample.rb
+++ b/app/models/mycorrhizal_fungi_sample.rb
@@ -22,6 +22,14 @@ class MycorrhizalFungiSample < ApplicationRecord
     visible_hyphae
   end
 
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
+
   def to_s
     "#{plot}, #{plant}, on #{collected_on} by #{user}"
   end

--- a/app/models/nonvascular_plant_sample.rb
+++ b/app/models/nonvascular_plant_sample.rb
@@ -11,6 +11,14 @@ class NonvascularPlantSample < ApplicationRecord
 
   paginates_per 10
 
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
+  
   def to_s
     "#{plot} on #{collected_on} by #{user}"
   end

--- a/app/models/plant_sample.rb
+++ b/app/models/plant_sample.rb
@@ -35,6 +35,14 @@ class PlantSample < ApplicationRecord
     end
   end
 
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
+
   def to_s
     "#{plot} on #{collected_on} by #{user}"
   end

--- a/app/models/plot.rb
+++ b/app/models/plot.rb
@@ -32,6 +32,10 @@ class Plot < ApplicationRecord
     remove_period(location_description.slice(0,1).capitalize + location_description.strip.slice(1..-1))
   end
 
+  def datestamp
+    updated_at&.to_formatted_s(:long)
+  end 
+
   private
 
   def remove_period(str)

--- a/app/models/plot.rb
+++ b/app/models/plot.rb
@@ -32,7 +32,7 @@ class Plot < ApplicationRecord
     remove_period(location_description.slice(0,1).capitalize + location_description.strip.slice(1..-1))
   end
 
-  def datestamp
+  def updated_string
     updated_at&.to_formatted_s(:long)
   end 
 

--- a/app/models/soil_sample.rb
+++ b/app/models/soil_sample.rb
@@ -30,6 +30,14 @@ class SoilSample < ApplicationRecord
     end
   end
 
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
+
   def to_s
     "#{plot} on #{collected_on} by #{user}"
   end

--- a/app/models/species_variation_observation.rb
+++ b/app/models/species_variation_observation.rb
@@ -11,6 +11,14 @@ class SpeciesVariationObservation < ApplicationRecord
 
   paginates_per 10
 
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    observed_on&.to_formatted_s(:long)
+  end
+
   def to_s
     "#{plant} in #{plot} on #{observed_on} by #{user}"
   end

--- a/app/models/tree_sample.rb
+++ b/app/models/tree_sample.rb
@@ -24,6 +24,14 @@ class TreeSample < ApplicationRecord
 
   paginates_per 10
 
+  def updated_string
+    updated_at&.to_formatted_s(:long)
+  end 
+
+  def datestamp
+    collected_on&.to_formatted_s(:long)
+  end
+
   def to_s
     "#{plant} in #{plot} on #{collected_on} by #{user}"
   end

--- a/app/views/biodiversity_reports/index.html.haml
+++ b/app/views/biodiversity_reports/index.html.haml
@@ -20,7 +20,7 @@
       - @biodiversity_reports.each do |report|
         %tr{:onclick => "location.href='#{url_for(report)}'"}
           %td= report.id
-          %td= report.measured_on.to_formatted_s(:long)
+          %td= report.datestamp
           %td= report.plot
           %td= report.temperature
           %td= report.species_richness

--- a/app/views/biodiversity_reports/show.html.haml
+++ b/app/views/biodiversity_reports/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@biodiversity_report)} #{link_to(@biodiversity_report.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@biodiversity_report)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= measured_on(@biodiversity_report)
+          %td= @biodiversity_report.datestamp
         %tr
           %th{scope: 'row'} Author
           %td= link_to(@biodiversity_report.author)

--- a/app/views/fungi_samples/index.html.haml
+++ b/app/views/fungi_samples/index.html.haml
@@ -18,7 +18,7 @@
       - @fungi_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= sample.location_within_plot
           %td= sample.size

--- a/app/views/fungi_samples/show.html.haml
+++ b/app/views/fungi_samples/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@fungi_sample)} #{link_to(@fungi_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@fungi_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@fungi_sample)
+          %td= @fungi_sample.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@fungi_sample.plot}", @fungi_sample.plot)

--- a/app/views/lichen_samples/index.html.haml
+++ b/app/views/lichen_samples/index.html.haml
@@ -17,7 +17,7 @@
       - @lichen_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= sample.location_within_plot
           %td= sample.description

--- a/app/views/lichen_samples/show.html.haml
+++ b/app/views/lichen_samples/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@lichen_sample)} #{link_to(@lichen_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@lichen_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@lichen_sample)
+          %td= @lichen_sample.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@lichen_sample.plot}", @lichen_sample.plot)

--- a/app/views/macroinvertebrate_samples/index.html.haml
+++ b/app/views/macroinvertebrate_samples/index.html.haml
@@ -19,7 +19,7 @@
       - @macroinvertebrate_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= sample.location_within_plot
           %td= sample.phylum

--- a/app/views/macroinvertebrate_samples/show.html.haml
+++ b/app/views/macroinvertebrate_samples/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@macroinvertebrate_sample)} #{link_to(@macroinvertebrate_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@macroinvertebrate_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@macroinvertebrate_sample)
+          %td= @macroinvertebrate_sample.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@macroinvertebrate_sample.plot}", @macroinvertebrate_sample.plot)

--- a/app/views/mycorrhizal_fungi_samples/index.html.haml
+++ b/app/views/mycorrhizal_fungi_samples/index.html.haml
@@ -21,7 +21,7 @@
       - @mycorrhizal_fungi_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= "#{sample.length}cm"
           %td= sample.magnification

--- a/app/views/mycorrhizal_fungi_samples/show.html.haml
+++ b/app/views/mycorrhizal_fungi_samples/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@mycorrhizal_fungi_sample)} #{link_to(@mycorrhizal_fungi_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@mycorrhizal_fungi_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@mycorrhizal_fungi_sample)
+          %td= @mycorrhizal_fungi_sample.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@mycorrhizal_fungi_sample.plot}", @mycorrhizal_fungi_sample.plot)

--- a/app/views/nonvascular_plant_samples/index.html.haml
+++ b/app/views/nonvascular_plant_samples/index.html.haml
@@ -17,7 +17,7 @@
       - @nonvascular_plant_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= sample.location_within_plot
           %td= sample.description

--- a/app/views/nonvascular_plant_samples/show.html.haml
+++ b/app/views/nonvascular_plant_samples/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@nonvascular_plant_sample)} #{link_to(@nonvascular_plant_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@nonvascular_plant_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@nonvascular_plant_sample)
+          %td= @nonvascular_plant_sample.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@nonvascular_plant_sample.plot}", @nonvascular_plant_sample.plot)

--- a/app/views/plant_samples/index.html.haml
+++ b/app/views/plant_samples/index.html.haml
@@ -19,7 +19,7 @@
       - @plant_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= sample.plant.common_name.titleize
           %td= sample.abundance

--- a/app/views/plant_samples/show.html.haml
+++ b/app/views/plant_samples/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@plant_sample)} #{link_to(@plant_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@plant_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@plant_sample)
+          %td= @plant_sample.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@plant_sample.plot}", @plant_sample.plot)

--- a/app/views/plots/show.html.haml
+++ b/app/views/plots/show.html.haml
@@ -29,7 +29,7 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'}= formatted_date(@plot)
+        %th.citation.italic{colspan: '2'}= last_updated(@plot)
       %tbody
         %tr
           %th{scope: 'row'} Featured Plant

--- a/app/views/soil_samples/index.html.haml
+++ b/app/views/soil_samples/index.html.haml
@@ -22,7 +22,7 @@
       - @soil_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= sample.collection_method
           %td= sample.ph_level

--- a/app/views/soil_samples/show.html.haml
+++ b/app/views/soil_samples/show.html.haml
@@ -12,11 +12,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@soil_sample)} #{link_to(@soil_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@soil_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@soil_sample)
+          %td= @soil_sample.datestamp
         %tr
           %th{scope: 'row'} Collection Method
           %td= @soil_sample.collection_method

--- a/app/views/species_variation_observations/index.html.haml
+++ b/app/views/species_variation_observations/index.html.haml
@@ -19,7 +19,7 @@
       - @species_variation_observations.each do |obs|
         %tr{:onclick => "location.href='#{url_for(obs)}'"}
           %td= obs.id
-          %td= observed_on(obs)
+          %td= obs.datestamp
           %td= obs.plot
           %td= obs.plant.common_name.titleize
           %td= obs.average_height

--- a/app/views/species_variation_observations/show.html.haml
+++ b/app/views/species_variation_observations/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@species_variation_observation)} #{link_to(@species_variation_observation.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@species_variation_observation)
       %tbody
         %tr
           %th{scope: 'row'} Observation Date
-          %td= observed_on(@species_variation_observation)
+          %td= @species_variation_observation.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@species_variation_observation.plot}", @species_variation_observation.plot)

--- a/app/views/tree_samples/index.html.haml
+++ b/app/views/tree_samples/index.html.haml
@@ -24,7 +24,7 @@
       - @tree_samples.each do |sample|
         %tr{:onclick => "location.href='#{url_for(sample)}'"}
           %td= sample.id
-          %td= collected_on(sample)
+          %td= sample.datestamp
           %td= sample.plot
           %td= sample.plant.common_name.titleize
           %td= sample.tag_number

--- a/app/views/tree_samples/show.html.haml
+++ b/app/views/tree_samples/show.html.haml
@@ -13,11 +13,11 @@
     %h2.heading#table-heading Information
     %table.table#vertical-table
       %thead
-        %th.citation.italic{colspan: '2'} #{last_updated(@tree_sample)} #{link_to(@tree_sample.user)}
+        %th.citation.italic{colspan: '2'}= last_updated(@tree_sample)
       %tbody
         %tr
           %th{scope: 'row'} Collection Date
-          %td= collected_on(@tree_sample)
+          %td= @tree_sample.datestamp
         %tr
           %th{scope: 'row'} Plot
           %td= link_to("#{@tree_sample.plot}", @tree_sample.plot)

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -17,4 +17,4 @@
       - @user.biodiversity_reports.order('measured_on DESC').each do |report|
         %tr{:onclick => "location.href='#{url_for(report)}'"}
           %td= report.to_s
-          %td= measured_on(report)
+          %td= report.datestamp

--- a/spec/models/biodiversity_report_spec.rb
+++ b/spec/models/biodiversity_report_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe BiodiversityReport, type: :model do
       expect(report.to_s).to eq("Biodiversity Report #{report.id}")
     end
 
-    it 'has a byline consisting of the author name, date and time' do
-      expect(report.byline).to eq("by #{report.author} on #{report.measured_on.to_formatted_s(:long)} at #{report.measured_at.to_formatted_s(:ampm)}")
-    end
   end
 
   describe 'validations' do

--- a/spec/models/soil_sample_spec.rb
+++ b/spec/models/soil_sample_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe SoilSample, type: :model do
   describe 'destruction' do
     it "destroys associated nutrients" do
       soil_sample = nutrient.soil_sample
-      byebug
       soil_sample.nutrients.reload
       soil_sample.destroy
       expect { nutrient.reload }.to raise_error(ActiveRecord::RecordNotFound)


### PR DESCRIPTION
Refactored collected_on, measured_on, and observed_on.  Instead of having all these options, each model handles it own internal attribute which is exposed to the outside world view datestamp.  last_updated was also refactored.  Instead of the views handling the logic, all logic is now handled in application helper.  Addresses issue #179 